### PR TITLE
Caches key names to IntPtrs to save allocations

### DIFF
--- a/src/FRC.NetworkTables.Core/Native/CoreMethods.cs
+++ b/src/FRC.NetworkTables.Core/Native/CoreMethods.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -45,7 +46,7 @@ namespace NetworkTables.Core.Native
         internal static bool SetDefaultEntryBoolean(string name, bool value)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             int retVal = Interop.NT_SetDefaultEntryBoolean(namePtr, size, value ? 1 : 0);
             return retVal != 0;
         }
@@ -53,7 +54,7 @@ namespace NetworkTables.Core.Native
         internal static bool SetDefaultEntryDouble(string name, double value)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             int retVal = Interop.NT_SetDefaultEntryDouble(namePtr, size, value);
             return retVal != 0;
         }
@@ -61,7 +62,7 @@ namespace NetworkTables.Core.Native
         internal static bool SetDefaultEntryString(string name, string value)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             UIntPtr stringSize;
             byte[] stringPtr = CreateUTF8String(value, out stringSize);
             int retVal = Interop.NT_SetDefaultEntryString(namePtr, size, stringPtr, stringSize);
@@ -71,7 +72,7 @@ namespace NetworkTables.Core.Native
         internal static bool SetDefaultEntryRaw(string name, byte[] value)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             int retVal = Interop.NT_SetDefaultEntryRaw(namePtr, size, value, (UIntPtr)value.Length);
             return retVal != 0;
         }
@@ -79,7 +80,7 @@ namespace NetworkTables.Core.Native
         internal static bool SetDefaultEntryBooleanArray(string name, bool[] value)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
 
             int[] valueIntArr = new int[value.Length];
             for (int i = 0; i < value.Length; i++)
@@ -95,7 +96,7 @@ namespace NetworkTables.Core.Native
         internal static bool SetDefaultEntryDoubleArray(string name, double[] value)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
 
             int retVal = Interop.NT_SetDefaultEntryDoubleArray(namePtr, size, value, (UIntPtr)value.Length);
 
@@ -105,7 +106,7 @@ namespace NetworkTables.Core.Native
         internal static bool SetDefaultEntryStringArray(string name, string[] value)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
 
             NtStringWrite[] ntStrings = new NtStringWrite[value.Length];
             for (int i = 0; i < value.Length; i++)
@@ -153,7 +154,7 @@ namespace NetworkTables.Core.Native
         internal static bool SetEntryBoolean(string name, bool value, bool force = false)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             int retVal = Interop.NT_SetEntryBoolean(namePtr, size, value ? 1 : 0, force ? 1 : 0);
             return retVal != 0;
         }
@@ -161,7 +162,7 @@ namespace NetworkTables.Core.Native
         internal static bool SetEntryDouble(string name, double value, bool force = false)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             int retVal = Interop.NT_SetEntryDouble(namePtr, size, value, force ? 1 : 0);
             return retVal != 0;
         }
@@ -169,7 +170,7 @@ namespace NetworkTables.Core.Native
         internal static bool SetEntryString(string name, string value, bool force = false)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             UIntPtr stringSize;
             byte[] stringPtr = CreateUTF8String(value, out stringSize);
             int retVal = Interop.NT_SetEntryString(namePtr, size, stringPtr, stringSize, force ? 1 : 0);
@@ -179,7 +180,7 @@ namespace NetworkTables.Core.Native
         internal static bool SetEntryRaw(string name, byte[] value, bool force = false)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             int retVal = Interop.NT_SetEntryRaw(namePtr, size, value, (UIntPtr) value.Length, force ? 1 : 0);
             return retVal != 0;
         }
@@ -187,7 +188,7 @@ namespace NetworkTables.Core.Native
         internal static bool SetEntryBooleanArray(string name, bool[] value, bool force = false)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
 
             int[] valueIntArr = new int[value.Length];
             for (int i = 0; i < value.Length; i++)
@@ -203,7 +204,7 @@ namespace NetworkTables.Core.Native
         internal static bool SetEntryDoubleArray(string name, double[] value, bool force = false)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
 
             int retVal = Interop.NT_SetEntryDoubleArray(namePtr, size, value, (UIntPtr) value.Length, force ? 1 : 0);
 
@@ -213,7 +214,7 @@ namespace NetworkTables.Core.Native
         internal static bool SetEntryStringArray(string name, string[] value, bool force = false)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
 
             NtStringWrite[] ntStrings = new NtStringWrite[value.Length];
             for (int i = 0; i < value.Length; i++)
@@ -238,7 +239,7 @@ namespace NetworkTables.Core.Native
         internal static bool GetEntryBoolean(string name, bool defaultValue)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             int boolean = 0;
             ulong lc = 0;
             int status = Interop.NT_GetEntryBoolean(namePtr, size, ref lc, ref boolean);
@@ -252,7 +253,7 @@ namespace NetworkTables.Core.Native
         internal static double GetEntryDouble(string name, double defaultValue)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             double retVal = 0;
             ulong lastChange = 0;
             int status = Interop.NT_GetEntryDouble(namePtr, size, ref lastChange, ref retVal);
@@ -266,7 +267,7 @@ namespace NetworkTables.Core.Native
         internal static string GetEntryString(string name, string defaultValue)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             UIntPtr stringSize = UIntPtr.Zero;
             ulong lastChange = 0;
             IntPtr ret = Interop.NT_GetEntryString(namePtr, size, ref lastChange, ref stringSize);
@@ -285,7 +286,7 @@ namespace NetworkTables.Core.Native
         internal static byte[] GetEntryRaw(string name, byte[] defaultValue)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             UIntPtr stringSize = UIntPtr.Zero;
             ulong lastChange = 0;
             IntPtr ret = Interop.NT_GetEntryRaw(namePtr, size, ref lastChange, ref stringSize);
@@ -304,7 +305,7 @@ namespace NetworkTables.Core.Native
         internal static double[] GetEntryDoubleArray(string name, double[] defaultValue)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             UIntPtr arrSize = UIntPtr.Zero;
             ulong lastChange = 0;
             IntPtr arrPtr = Interop.NT_GetEntryDoubleArray(namePtr, size, ref lastChange, ref arrSize);
@@ -320,7 +321,7 @@ namespace NetworkTables.Core.Native
         internal static bool[] GetEntryBooleanArray(string name, bool[] defaultValue)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             UIntPtr arrSize = UIntPtr.Zero;
             ulong lastChange = 0;
             IntPtr arrPtr = Interop.NT_GetEntryBooleanArray(namePtr, size, ref lastChange, ref arrSize);
@@ -336,7 +337,7 @@ namespace NetworkTables.Core.Native
         internal static string[] GetEntryStringArray(string name, string[] defaultValue)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             UIntPtr arrSize = UIntPtr.Zero;
             ulong lastChange = 0;
             IntPtr arrPtr = Interop.NT_GetEntryStringArray(namePtr, size, ref lastChange, ref arrSize);
@@ -384,7 +385,7 @@ namespace NetworkTables.Core.Native
             }
         }
 
-        private static void ThrowException(string name, byte[] namePtr, UIntPtr size, NtType requestedType)
+        private static void ThrowException(string name, IntPtr namePtr, UIntPtr size, NtType requestedType)
         {
             NtType typeInTable = Interop.NT_GetType(namePtr, size);
             if (typeInTable == NtType.Unassigned)
@@ -400,7 +401,7 @@ namespace NetworkTables.Core.Native
         internal static bool GetEntryBoolean(string name)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             int boolean = 0;
             ulong lc = 0;
             int status = Interop.NT_GetEntryBoolean(namePtr, size, ref lc, ref boolean);
@@ -414,7 +415,7 @@ namespace NetworkTables.Core.Native
         internal static double GetEntryDouble(string name)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             double retVal = 0;
             ulong lastChange = 0;
             int status = Interop.NT_GetEntryDouble(namePtr, size, ref lastChange, ref retVal);
@@ -428,7 +429,7 @@ namespace NetworkTables.Core.Native
         internal static string GetEntryString(string name)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             UIntPtr stringSize = UIntPtr.Zero;
             ulong lastChange = 0;
             IntPtr ret = Interop.NT_GetEntryString(namePtr, size, ref lastChange, ref stringSize);
@@ -444,7 +445,7 @@ namespace NetworkTables.Core.Native
         internal static byte[] GetEntryRaw(string name)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             UIntPtr stringSize = UIntPtr.Zero;
             ulong lastChange = 0;
             IntPtr ret = Interop.NT_GetEntryRaw(namePtr, size, ref lastChange, ref stringSize);
@@ -460,7 +461,7 @@ namespace NetworkTables.Core.Native
         internal static double[] GetEntryDoubleArray(string name)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             UIntPtr arrSize = UIntPtr.Zero;
             ulong lastChange = 0;
             IntPtr arrPtr = Interop.NT_GetEntryDoubleArray(namePtr, size, ref lastChange, ref arrSize);
@@ -476,7 +477,7 @@ namespace NetworkTables.Core.Native
         internal static bool[] GetEntryBooleanArray(string name)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             UIntPtr arrSize = UIntPtr.Zero;
             ulong lastChange = 0;
             IntPtr arrPtr = Interop.NT_GetEntryBooleanArray(namePtr, size, ref lastChange, ref arrSize);
@@ -492,7 +493,7 @@ namespace NetworkTables.Core.Native
         internal static string[] GetEntryStringArray(string name)
         {
             UIntPtr size;
-            byte[] namePtr = CreateUTF8String(name, out size);
+            IntPtr namePtr = CreateCachedUTF8String(name, out size);
             UIntPtr arrSize = UIntPtr.Zero;
             ulong lastChange = 0;
             IntPtr arrPtr = Interop.NT_GetEntryStringArray(namePtr, size, ref lastChange, ref arrSize);
@@ -799,14 +800,14 @@ namespace NetworkTables.Core.Native
         internal static void SetEntryFlags(string name, EntryFlags flags)
         {
             UIntPtr size;
-            byte[] str = CreateUTF8String(name, out size);
+            IntPtr str = CreateCachedUTF8String(name, out size);
             Interop.NT_SetEntryFlags(str, size, (uint) flags);
         }
 
         internal static EntryFlags GetEntryFlags(string name)
         {
             UIntPtr size;
-            byte[] str = CreateUTF8String(name, out size);
+            IntPtr str = CreateCachedUTF8String(name, out size);
             uint flags = Interop.NT_GetEntryFlags(str, size);
             return (EntryFlags) flags;
         }
@@ -818,7 +819,7 @@ namespace NetworkTables.Core.Native
         internal static void DeleteEntry(string name)
         {
             UIntPtr size;
-            byte[] str = CreateUTF8String(name, out size);
+            IntPtr str = CreateCachedUTF8String(name, out size);
             Interop.NT_DeleteEntry(str, size);
         }
 
@@ -840,7 +841,7 @@ namespace NetworkTables.Core.Native
         internal static NtType GetType(string name)
         {
             UIntPtr size;
-            byte[] str = CreateUTF8String(name, out size);
+            IntPtr str = CreateCachedUTF8String(name, out size);
             NtType retVal = Interop.NT_GetType(str, size);
             return retVal;
         }
@@ -933,6 +934,15 @@ namespace NetworkTables.Core.Native
         #endregion
 
         #region IntPtrs To String Conversions
+
+        private static ConcurrentDictionary<string, NtStringWrite> s_keyCache = new ConcurrentDictionary<string, NtStringWrite>();
+
+        internal static IntPtr CreateCachedUTF8String(string str, out UIntPtr size)
+        {
+            NtStringWrite ntStr = s_keyCache.GetOrAdd(str, s => new NtStringWrite(s));
+            size = ntStr.len;
+            return ntStr.str;
+        }
 
         internal static byte[] CreateUTF8String(string str, out UIntPtr size)
         {

--- a/src/FRC.NetworkTables.Core/Native/Interop.cs
+++ b/src/FRC.NetworkTables.Core/Native/Interop.cs
@@ -245,11 +245,11 @@ namespace NetworkTables.Core.Native
 
         //Interup Functions
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void NT_SetEntryFlagsDelegate(byte[] name, UIntPtr name_len, uint flags);
+        internal delegate void NT_SetEntryFlagsDelegate(IntPtr name, UIntPtr name_len, uint flags);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate uint NT_GetEntryFlagsDelegate(byte[] name, UIntPtr name_len);
+        internal delegate uint NT_GetEntryFlagsDelegate(IntPtr name, UIntPtr name_len);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void NT_DeleteEntryDelegate(byte[] name, UIntPtr name_len);
+        internal delegate void NT_DeleteEntryDelegate(IntPtr name, UIntPtr name_len);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void NT_DeleteAllEntriesDelegate();
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -297,7 +297,7 @@ namespace NetworkTables.Core.Native
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void NT_DisposeStringDelegate(ref NtStringRead str);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate NtType NT_GetTypeDelegate(byte[] name, UIntPtr name_len);
+        internal delegate NtType NT_GetTypeDelegate(IntPtr name, UIntPtr name_len);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void NT_DisposeConnectionInfoArrayDelegate(IntPtr arr, UIntPtr count);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -333,58 +333,58 @@ namespace NetworkTables.Core.Native
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate IntPtr NT_GetValueStringArrayDelegate(IntPtr value, ref ulong last_change, ref UIntPtr size);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate int NT_GetEntryBooleanDelegate(byte[] name, UIntPtr name_len, ref ulong last_change, ref int v_boolean);
+        internal delegate int NT_GetEntryBooleanDelegate(IntPtr name, UIntPtr name_len, ref ulong last_change, ref int v_boolean);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate int NT_GetEntryDoubleDelegate(byte[] name, UIntPtr name_len, ref ulong last_change, ref double v_double);
+        internal delegate int NT_GetEntryDoubleDelegate(IntPtr name, UIntPtr name_len, ref ulong last_change, ref double v_double);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate IntPtr NT_GetEntryStringDelegate(byte[] name, UIntPtr name_len, ref ulong last_change, ref UIntPtr string_len);
+        internal delegate IntPtr NT_GetEntryStringDelegate(IntPtr name, UIntPtr name_len, ref ulong last_change, ref UIntPtr string_len);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate IntPtr NT_GetEntryRawDelegate(byte[] name, UIntPtr name_len, ref ulong last_change, ref UIntPtr raw_len);
+        internal delegate IntPtr NT_GetEntryRawDelegate(IntPtr name, UIntPtr name_len, ref ulong last_change, ref UIntPtr raw_len);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate IntPtr NT_GetEntryBooleanArrayDelegate(byte[] name, UIntPtr name_len, ref ulong last_change, ref UIntPtr size);
+        internal delegate IntPtr NT_GetEntryBooleanArrayDelegate(IntPtr name, UIntPtr name_len, ref ulong last_change, ref UIntPtr size);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate IntPtr NT_GetEntryDoubleArrayDelegate(byte[] name, UIntPtr name_len, ref ulong last_change, ref UIntPtr size);
+        internal delegate IntPtr NT_GetEntryDoubleArrayDelegate(IntPtr name, UIntPtr name_len, ref ulong last_change, ref UIntPtr size);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate IntPtr NT_GetEntryStringArrayDelegate(byte[] name, UIntPtr name_len, ref ulong last_change, ref UIntPtr size);
+        internal delegate IntPtr NT_GetEntryStringArrayDelegate(IntPtr name, UIntPtr name_len, ref ulong last_change, ref UIntPtr size);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate int NT_SetEntryBooleanDelegate(byte[] name, UIntPtr name_len, int v_boolean, int force);
+        internal delegate int NT_SetEntryBooleanDelegate(IntPtr name, UIntPtr name_len, int v_boolean, int force);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate int NT_SetEntryDoubleDelegate(byte[] name, UIntPtr name_len, double v_double, int force);
+        internal delegate int NT_SetEntryDoubleDelegate(IntPtr name, UIntPtr name_len, double v_double, int force);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate int NT_SetEntryStringDelegate(byte[] name, UIntPtr name_len, byte[] v_string, UIntPtr string_len, int force);
+        internal delegate int NT_SetEntryStringDelegate(IntPtr name, UIntPtr name_len, byte[] v_string, UIntPtr string_len, int force);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate int NT_SetEntryRawDelegate(byte[] name, UIntPtr name_len, byte[] raw, UIntPtr raw_len, int force);
+        internal delegate int NT_SetEntryRawDelegate(IntPtr name, UIntPtr name_len, byte[] raw, UIntPtr raw_len, int force);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate int NT_SetEntryBooleanArrayDelegate(byte[] name, UIntPtr name_len, int[] arr, UIntPtr size, int force);
+        internal delegate int NT_SetEntryBooleanArrayDelegate(IntPtr name, UIntPtr name_len, int[] arr, UIntPtr size, int force);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate int NT_SetEntryDoubleArrayDelegate(byte[] name, UIntPtr name_len, double[] arr, UIntPtr size, int force);
+        internal delegate int NT_SetEntryDoubleArrayDelegate(IntPtr name, UIntPtr name_len, double[] arr, UIntPtr size, int force);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate int NT_SetEntryStringArrayDelegate(byte[] name, UIntPtr name_len, NtStringWrite[] arr, UIntPtr size, int force);
+        internal delegate int NT_SetEntryStringArrayDelegate(IntPtr name, UIntPtr name_len, NtStringWrite[] arr, UIntPtr size, int force);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate int NT_SetDefaultEntryBooleanDelegate(byte[] name, UIntPtr name_len, int v_boolean);
+        internal delegate int NT_SetDefaultEntryBooleanDelegate(IntPtr name, UIntPtr name_len, int v_boolean);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate int NT_SetDefaultEntryDoubleDelegate(byte[] name, UIntPtr name_len, double v_double);
+        internal delegate int NT_SetDefaultEntryDoubleDelegate(IntPtr name, UIntPtr name_len, double v_double);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate int NT_SetDefaultEntryStringDelegate(byte[] name, UIntPtr name_len, byte[] v_string, UIntPtr string_len);
+        internal delegate int NT_SetDefaultEntryStringDelegate(IntPtr name, UIntPtr name_len, byte[] v_string, UIntPtr string_len);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate int NT_SetDefaultEntryRawDelegate(byte[] name, UIntPtr name_len, byte[] raw, UIntPtr raw_len);
+        internal delegate int NT_SetDefaultEntryRawDelegate(IntPtr name, UIntPtr name_len, byte[] raw, UIntPtr raw_len);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate int NT_SetDefaultEntryBooleanArrayDelegate(byte[] name, UIntPtr name_len, int[] arr, UIntPtr size);
+        internal delegate int NT_SetDefaultEntryBooleanArrayDelegate(IntPtr name, UIntPtr name_len, int[] arr, UIntPtr size);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate int NT_SetDefaultEntryDoubleArrayDelegate(byte[] name, UIntPtr name_len, double[] arr, UIntPtr size);
+        internal delegate int NT_SetDefaultEntryDoubleArrayDelegate(IntPtr name, UIntPtr name_len, double[] arr, UIntPtr size);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate int NT_SetDefaultEntryStringArrayDelegate(byte[] name, UIntPtr name_len, NtStringWrite[] arr, UIntPtr size);
+        internal delegate int NT_SetDefaultEntryStringArrayDelegate(IntPtr name, UIntPtr name_len, NtStringWrite[] arr, UIntPtr size);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void NT_CreateRpcDelegate(byte[] name, UIntPtr name_len, byte[] def, UIntPtr def_len, IntPtr data, NT_RPCCallback callback);
+        internal delegate void NT_CreateRpcDelegate(IntPtr name, UIntPtr name_len, byte[] def, UIntPtr def_len, IntPtr data, NT_RPCCallback callback);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void NT_CreatePolledRpcDelegate(byte[] name, UIntPtr name_len, byte[] def, UIntPtr def_len);
+        internal delegate void NT_CreatePolledRpcDelegate(IntPtr name, UIntPtr name_len, byte[] def, UIntPtr def_len);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int NT_PollRpcDelegate(int blocking, out NtRpcCallInfo call_info);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void NT_PostRpcResponseDelegate(uint rpc_id, uint call_uid, byte[] result, UIntPtr result_len);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate uint NT_CallRpcDelegate(byte[] name, UIntPtr name_len, byte[] param, UIntPtr params_len);
+        internal delegate uint NT_CallRpcDelegate(IntPtr name, UIntPtr name_len, byte[] param, UIntPtr params_len);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate IntPtr NT_GetRpcResultDelegate(int blocking, uint call_uid, ref UIntPtr result_len);
 

--- a/src/Shared/RemoteProcedureCall.cs
+++ b/src/Shared/RemoteProcedureCall.cs
@@ -46,7 +46,7 @@ namespace NetworkTables
                     return retPtr;
                 };
             UIntPtr nameLen;
-            byte[] nameB = CoreMethods.CreateUTF8String(name, out nameLen);
+            IntPtr nameB = CoreMethods.CreateCachedUTF8String(name, out nameLen);
             Interop.NT_CreateRpc(nameB, nameLen, def, (UIntPtr)def.Length, IntPtr.Zero, modCallback);
             s_rpcCallbacks.Add(modCallback);
 #else
@@ -84,7 +84,7 @@ namespace NetworkTables
         {
 #if CORE
             UIntPtr nameLen;
-            byte[] nameB = CoreMethods.CreateUTF8String(name, out nameLen);
+            IntPtr nameB = CoreMethods.CreateCachedUTF8String(name, out nameLen);
             Interop.NT_CreatePolledRpc(nameB, nameLen, def, (UIntPtr)def.Length);
 #else
             Storage.Instance.CreatePolledRpc(name, def);
@@ -221,7 +221,7 @@ namespace NetworkTables
         {
 #if CORE
             UIntPtr size;
-            byte[] nameB = CoreMethods.CreateUTF8String(name, out size);
+            IntPtr nameB = CoreMethods.CreateCachedUTF8String(name, out size);
             return Interop.NT_CallRpc(nameB, size, param, (UIntPtr)param.Length);
 #else
             return Storage.Instance.CallRpc(name, param);


### PR DESCRIPTION
Previously, every key was converted to a UTF8 byte[], which would always cause an array allocation. Things that are specifically keys are cached to now only created once and then resused.