### PR TITLE
Switches versions to 3.0.0

### DIFF
--- a/src/FRC.NetworkTables.Core/project.json
+++ b/src/FRC.NetworkTables.Core/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2017.0.1-beta-*",
+  "version": "3.0.0-beta-*",
   "title": "FRC NetworkTables.Core",
   "description": "NetworkTables using the ntcore library.",
   "copyright": "Copyright 2016 RobotDotNet",

--- a/src/FRC.NetworkTables/project.json
+++ b/src/FRC.NetworkTables/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2017.0.1-beta-*",
+  "version": "3.0.0-beta-*",
   "title": "FRC NetworkTables",
   "description": "A Managed version of the NetworkTables3 Protocol.",
   "copyright": "Copyright 2016 RobotDotNet",


### PR DESCRIPTION
WPILib is moving ntcore to semver and starting at 3.0.0, so it is no
longer a yearly dependancy. Switches here. I'll remove the old versions
from NuGet once these are published.