### PR TITLE
Adds fast bitconverter code

### DIFF
--- a/NetworkTables.xproj.sln
+++ b/NetworkTables.xproj.sln
@@ -38,6 +38,9 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NetworkTables.Core.Test", "
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Wire", "Wire", "{1046D479-84E0-47C7-8EAA-8A032FCE39B4}"
 	ProjectSection(SolutionItems) = preProject
+		src\Shared\Wire\FastBitConverterBE.cs = src\Shared\Wire\FastBitConverterBE.cs
+		src\Shared\Wire\FastBitConverterLE.cs = src\Shared\Wire\FastBitConverterLE.cs
+		src\Shared\Wire\IFastBitConverter.cs = src\Shared\Wire\IFastBitConverter.cs
 		src\Shared\Wire\Leb128.cs = src\Shared\Wire\Leb128.cs
 		src\Shared\Wire\WireDecoder.cs = src\Shared\Wire\WireDecoder.cs
 		src\Shared\Wire\WireEncoder.cs = src\Shared\Wire\WireEncoder.cs

--- a/src/Shared/Wire/FastBitConverterBE.cs
+++ b/src/Shared/Wire/FastBitConverterBE.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace NetworkTables.Wire
+{
+    internal class FastBitConverterBE : IFastBitConverter
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [System.Security.SecuritySafeCritical]
+        public void AddUShort(List<byte> list, ushort val)
+        {
+            list.Add((byte)(val & 0xff));
+            list.Add((byte)((val >> 8) & 0xff));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [System.Security.SecuritySafeCritical]
+        public void AddShort(List<byte> list, short val)
+        {
+            list.Add((byte)(val & 0xff));
+            list.Add((byte)((val >> 8) & 0xff));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [System.Security.SecuritySafeCritical]
+        public void AddUInt(List<byte> list, uint val)
+        {
+            list.Add((byte)(val & 0xff));
+            list.Add((byte)((val >> 8) & 0xff));
+            list.Add((byte)((val >> 16) & 0xff));
+            list.Add((byte)((val >> 24) & 0xff));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [System.Security.SecuritySafeCritical]
+        public void AddInt(List<byte> list, int val)
+        {
+            list.Add((byte)(val & 0xff));
+            list.Add((byte)((val >> 8) & 0xff));
+            list.Add((byte)((val >> 16) & 0xff));
+            list.Add((byte)((val >> 24) & 0xff));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [System.Security.SecuritySafeCritical]
+        public void AddULong(List<byte> list, ulong val)
+        {
+            list.Add((byte)(val & 0xff));
+            list.Add((byte)((val >> 8) & 0xff));
+            list.Add((byte)((val >> 16) & 0xff));
+            list.Add((byte)((val >> 24) & 0xff));
+            list.Add((byte)((val >> 32) & 0xff));
+            list.Add((byte)((val >> 40) & 0xff));
+            list.Add((byte)((val >> 48) & 0xff));
+            list.Add((byte)((val >> 56) & 0xff));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [System.Security.SecuritySafeCritical]
+        public void AddLong(List<byte> list, long val)
+        {
+            list.Add((byte)(val & 0xff));
+            list.Add((byte)((val >> 8) & 0xff));
+            list.Add((byte)((val >> 16) & 0xff));
+            list.Add((byte)((val >> 24) & 0xff));
+            list.Add((byte)((val >> 32) & 0xff));
+            list.Add((byte)((val >> 40) & 0xff));
+            list.Add((byte)((val >> 48) & 0xff));
+            list.Add((byte)((val >> 56) & 0xff));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [System.Security.SecuritySafeCritical]
+        public void AddDouble(List<byte> list, double val)
+        {
+            AddLong(list, BitConverter.DoubleToInt64Bits(val));
+        }
+    }
+}

--- a/src/Shared/Wire/FastBitConverterLE.cs
+++ b/src/Shared/Wire/FastBitConverterLE.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace NetworkTables.Wire
+{
+    internal class FastBitConverterLE : IFastBitConverter
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [System.Security.SecuritySafeCritical]
+        public void AddUShort(List<byte> list, ushort val)
+        {
+            list.Add((byte)((val >> 8) & 0xff));
+            list.Add((byte)(val & 0xff));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [System.Security.SecuritySafeCritical]
+        public void AddShort(List<byte> list, short val)
+        {
+            list.Add((byte)((val >> 8) & 0xff));
+            list.Add((byte)(val & 0xff));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [System.Security.SecuritySafeCritical]
+        public void AddUInt(List<byte> list, uint val)
+        {
+            list.Add((byte)((val >> 24) & 0xff));
+            list.Add((byte)((val >> 16) & 0xff));
+            list.Add((byte)((val >> 8) & 0xff));
+            list.Add((byte)(val & 0xff));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [System.Security.SecuritySafeCritical]
+        public void AddInt(List<byte> list, int val)
+        {
+            list.Add((byte)((val >> 24) & 0xff));
+            list.Add((byte)((val >> 16) & 0xff));
+            list.Add((byte)((val >> 8) & 0xff));
+            list.Add((byte)(val & 0xff));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [System.Security.SecuritySafeCritical]
+        public void AddULong(List<byte> list, ulong val)
+        {
+            list.Add((byte)((val >> 56) & 0xff));
+            list.Add((byte)((val >> 48) & 0xff));
+            list.Add((byte)((val >> 40) & 0xff));
+            list.Add((byte)((val >> 32) & 0xff));
+            list.Add((byte)((val >> 24) & 0xff));
+            list.Add((byte)((val >> 16) & 0xff));
+            list.Add((byte)((val >> 8) & 0xff));
+            list.Add((byte)(val & 0xff));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [System.Security.SecuritySafeCritical]
+        public void AddLong(List<byte> list, long val)
+        {
+            list.Add((byte)((val >> 56) & 0xff));
+            list.Add((byte)((val >> 48) & 0xff));
+            list.Add((byte)((val >> 40) & 0xff));
+            list.Add((byte)((val >> 32) & 0xff));
+            list.Add((byte)((val >> 24) & 0xff));
+            list.Add((byte)((val >> 16) & 0xff));
+            list.Add((byte)((val >> 8) & 0xff));
+            list.Add((byte)(val & 0xff));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [System.Security.SecuritySafeCritical]
+        public void AddDouble(List<byte> list, double val)
+        {
+            AddLong(list, BitConverter.DoubleToInt64Bits(val));
+        }
+    }
+}

--- a/src/Shared/Wire/IFastBitConverter.cs
+++ b/src/Shared/Wire/IFastBitConverter.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NetworkTables.Wire
+{
+    internal interface IFastBitConverter
+    {
+        void AddUShort(List<byte> list, ushort val);
+        void AddShort(List<byte> list, short val);
+        void AddUInt(List<byte> list, uint val);
+        void AddInt(List<byte> list, int val);
+        void AddULong(List<byte> list, ulong val);
+        void AddLong(List<byte> list, long val);
+        void AddDouble(List<byte> list, double val);
+    }
+}

--- a/src/Shared/Wire/WireEncoder.cs
+++ b/src/Shared/Wire/WireEncoder.cs
@@ -10,6 +10,8 @@ namespace NetworkTables.Wire
     /// </summary>
     public class WireEncoder
     {
+        private IFastBitConverter m_fastBitConverter;
+
         private readonly List<byte> m_buffer = new List<byte>(1024);
 
         /// <summary>
@@ -28,9 +30,7 @@ namespace NetworkTables.Wire
         /// <param name="val">The value to write</param>
         public void WriteDouble(double val)
         {
-            byte[] bytes = BitConverter.GetBytes(IPAddress.HostToNetworkOrder(BitConverter.DoubleToInt64Bits(val)));
-
-            m_buffer.AddRange(bytes);
+            m_fastBitConverter.AddDouble(m_buffer, val);
         }
 
         /// <summary>
@@ -50,6 +50,14 @@ namespace NetworkTables.Wire
         /// <param name="protoRev">The protocol vision for the encoder</param>
         public WireEncoder(int protoRev)
         {
+            if (BitConverter.IsLittleEndian)
+            {
+                m_fastBitConverter = new FastBitConverterLE();
+            }
+            else
+            {
+                m_fastBitConverter = new FastBitConverterBE();
+            }
             ProtoRev = protoRev;
         }
 
@@ -77,8 +85,7 @@ namespace NetworkTables.Wire
         /// <param name="val">The ushort to write to the encoder</param>
         public void Write16(ushort val)
         {
-            var tmp = BitConverter.GetBytes(IPAddress.HostToNetworkOrder((short)val));
-            m_buffer.AddRange(tmp);
+            m_fastBitConverter.AddUShort(m_buffer, val);
         }
 
         /// <summary>
@@ -87,7 +94,7 @@ namespace NetworkTables.Wire
         /// <param name="val">The uint to write to the encoder</param>
         public void Write32(uint val)
         {
-            m_buffer.AddRange(BitConverter.GetBytes(IPAddress.HostToNetworkOrder((int)val)));
+            m_fastBitConverter.AddUInt(m_buffer, val);
         }
 
         /// <summary>


### PR DESCRIPTION
Previously always involved allocations, which was slow and had a lot of
memory allocations. New code uses unsafe code, but is MUCH faster.