### PR TITLE
Small modification so SmartDashboard can monitor network connection status

### DIFF
--- a/src/FRC.NetworkTables/TcpSockets/TcpConnector.cs
+++ b/src/FRC.NetworkTables/TcpSockets/TcpConnector.cs
@@ -26,7 +26,10 @@ namespace NetworkTables.TcpSockets
                     // Sockets don't all support IPV6
                     if (ipAddress.AddressFamily == AddressFamily.InterNetwork)
                     {
-                        addresses.Add(ipAddress);
+                        if (!addresses.Contains(ipAddress))
+                        {
+                            addresses.Add(ipAddress);
+                        }
                     }
                 }
                 addr = addresses.ToArray();

--- a/src/Shared/NetworkTable.cs
+++ b/src/Shared/NetworkTable.cs
@@ -1041,6 +1041,11 @@ namespace NetworkTables
             return NtCore.GetConnections();
         }
 
+        public static int AddConnectionListener(ConnectionListenerCallback callback, bool immediateNotify)
+        {
+            return NtCore.AddConnectionListener(callback, immediateNotify);
+        }
+
         /// <inheritdoc/>
         public bool SetDefaultValue(string key, Value defaultValue)
         {

--- a/src/Shared/NetworkTable.cs
+++ b/src/Shared/NetworkTable.cs
@@ -1041,9 +1041,24 @@ namespace NetworkTables
             return NtCore.GetConnections();
         }
 
+        /// <summary>
+        /// Adds a connection listener to the table
+        /// </summary>
+        /// <param name="callback">The callback to call when a new remote connects or disconnects</param>
+        /// <param name="immediateNotify">True to notify immediately with all connected remotes</param>
+        /// <returns>The id of the connection listener</returns>
         public static int AddConnectionListener(ConnectionListenerCallback callback, bool immediateNotify)
         {
             return NtCore.AddConnectionListener(callback, immediateNotify);
+        }
+
+        /// <summary>
+        /// Removes a connection listener from the table
+        /// </summary>
+        /// <param name="uid">The connection listener id</param>
+        public static void RemoveConnectionListener(int uid)
+        {
+            NtCore.RemoveConnectionListener(uid);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
At the moment the SmartDashboard does a one off check of the NetworkTable connection status. As such the icon on the SmartDashboard cannot be relied upon should the status change. This pull request is to add an event to the NetworkTable class so the SmartDashboard can receive notifications when the connection status changes.