### PR TITLE
Removes Async Polled API from NetworkTables.Core

### DIFF
--- a/src/Shared/RemoteProcedureCall.cs
+++ b/src/Shared/RemoteProcedureCall.cs
@@ -132,6 +132,7 @@ namespace NetworkTables
 #endif
         }
 
+#if !CORE
         /// <summary>
         /// Polls for an Rpc request from a client asynchronously
         /// </summary>
@@ -164,6 +165,7 @@ namespace NetworkTables
             return await RpcServer.Instance.PollRpcAsync(token).ConfigureAwait(false);
 #endif
         }
+#endif
 
         /// <summary>
         /// Polls for an Rpc request from a client

--- a/test/NetworkTables.Core.Test/TestRPC.cs
+++ b/test/NetworkTables.Core.Test/TestRPC.cs
@@ -55,6 +55,7 @@ namespace NetworkTables.Core.Test
 
         
         //[Test]
+        /*
         public void TestPolledRpcAsync()
         {
             Console.WriteLine("TestPolledRpcAsync");
@@ -87,6 +88,7 @@ namespace NetworkTables.Core.Test
 
             Console.WriteLine(call1Result[0].ToString());
         }
+        */
         
 
         [Test]


### PR DESCRIPTION
Not supported and not easy to support either. Used to throw an exception. Now just does not exist.